### PR TITLE
Changes the tag field on form to a TagField, and adds tests to the parsers. Fixes #2.

### DIFF
--- a/booru/forms.py
+++ b/booru/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 from .models import Post
+from taggit.forms import TagField
 
 class CreatePostForm(forms.ModelForm):
     '''Form for creating an post.'''
@@ -7,7 +8,7 @@ class CreatePostForm(forms.ModelForm):
     image = forms.ImageField(widget=forms.FileInput(attrs={'class': 'custom-file-input'}), required=True)
     sample = forms.ImageField(required=False)
     preview = forms.ImageField(required=False)
-    tags = forms.CharField(widget=forms.TextInput(attrs={'class': 'form-control'}), required=True)
+    tags = TagField(widget=forms.TextInput(attrs={'class': 'form-control'}), required=True)
     source = forms.URLField(widget=forms.TextInput(attrs={'class': 'form-control'}), required=False)
 
     class Meta:

--- a/booru/tests.py
+++ b/booru/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/booru/tests/tests_booru_utilities.py
+++ b/booru/tests/tests_booru_utilities.py
@@ -28,9 +28,3 @@ class UtilitiesTests(TestCase):
         generated_tags = space_splitter(tag_string)
         expected_generated_tags = ["test1", "test2", "test:test_3", "test_4"]
         self.assertEqual(generated_tags, expected_generated_tags)
-
-    def test_space_joiner_turns_tags_into_a_string(self):
-        tags = ["test4", "test_5", "test:test6"]
-        generated_string = space_joiner(tags)
-        expected_generated_string = "test4 test_5 test:test6"
-        self.assertEqual(generated_string, expected_generated_string)

--- a/booru/tests/tests_booru_utilities.py
+++ b/booru/tests/tests_booru_utilities.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+import re
+import tempfile
+from collections import Counter
+from urllib.parse import urlparse
+
+import django
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser, User
+from django.test import Client, RequestFactory, TestCase
+from django.test.utils import override_settings
+from booru.utils import space_splitter
+from booru.utils import space_joiner
+
+class UtilitiesTests(TestCase):
+    fixtures = []
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+
+    def test_space_splitter_generates_tags_from_string(self):
+        tag_string = "test1 test2 test:test_3 test_4"
+        generated_tags = space_splitter(tag_string)
+        expected_generated_tags = ["test1", "test2", "test:test_3", "test_4"]
+        self.assertEqual(generated_tags, expected_generated_tags)
+
+    def test_space_joiner_turns_tags_into_a_string(self):
+        tags = ["test4", "test_5", "test:test6"]
+        generated_string = space_joiner(tags)
+        expected_generated_string = "test4 test_5 test:test6"
+        self.assertEqual(generated_string, expected_generated_string)


### PR DESCRIPTION
The problem was in using a CharField instead of a TagField (undocumented on django-taggit) on the CreatePostForm.