### PR TITLE
Changed references to old modules and functions

### DIFF
--- a/account/urls.py
+++ b/account/urls.py
@@ -1,4 +1,3 @@
-from django.conf.urls import url
 from django.urls import path
 
 from . import views

--- a/booru/urls.py
+++ b/booru/urls.py
@@ -1,29 +1,29 @@
-from django.urls import path
-from django.conf.urls import url
+from django.urls import re_path, path
 
 from . import views
 
 app_name = "booru"
 
 urlpatterns = [
-    url(r'^$', views.index, name='index'),
-    url(r'^post/view/(?P<post_id>[0-9]+)/$', views.post_detail, name='post_detail'),
-    url(r'^upload/$', views.upload, name='upload'),
-    url(r'^post/list/$', views.post_list_detail, name='posts'),
-    url(r'^post/list/(?P<page_number>[0-9]+)/$', views.post_list_detail, name='post_page_detail'),
-    url(r'^tags/$', views.tags_list, name='tags_list'),
-    url(r'^tags/list/(?P<page_number>[0-9]+)/$', views.tags_list, name='tags_page_list'),
-    url(r'^tags/(?P<tag_id>[0-9]+)/edit/$', views.tag_edit, name='tag_edit'),
+    re_path(r'^$', views.index, name='index'),
+    re_path(r'^post/view/(?P<post_id>[0-9]+)/$', views.post_detail, name='post_detail'),
+    re_path(r'^upload/$', views.upload, name='upload'),
+    re_path(r'^post/list/$', views.post_list_detail, name='posts'),
+    re_path(r'^post/list/(?P<page_number>[0-9]+)/$', views.post_list_detail, name='post_page_detail'),
+    re_path(r'^tags/$', views.tags_list, name='tags_list'),
+    re_path(r'^tags/list/(?P<page_number>[0-9]+)/$', views.tags_list, name='tags_page_list'),
+    re_path(r'^tags/(?P<tag_id>[0-9]+)/edit/$', views.tag_edit, name='tag_edit'),
     path('tag_implications', views.ImplicationListView.as_view(), name='implication-list'),
     path('tag_implications/<int:pk>/', views.ImplicationDetailView.as_view(), name='implication-detail'),
     path('tag_aliases', views.AliasListView.as_view(), name='alias-list'),
     path('tag_aliases/<int:pk>/', views.AliasDetailView.as_view(), name='alias-detail'),
 
-    url(r'^tag_alias_request/$', views.alias_create, name='alias_create'),
-    url(r'^tag_implication_request/$', views.implication_create, name='implication_create'),
+    re_path(r'^tag_alias_request/$', views.alias_create, name='alias_create'),
+    re_path(r'^tag_implication_request/$', views.implication_create, name='implication_create'),
 
-    url(r'^tag_aliases/(?P<alias_id>[0-9]+)/approve/$', views.alias_approve, name='alias_approve'),
-    url(r'^tag_implications/(?P<implication_id>[0-9]+)/approve/$', views.implication_approve, name='implication_approve'),
-    url(r'^tag_aliases/(?P<alias_id>[0-9]+)/disapprove/$', views.alias_disapprove, name='alias_disapprove'),
-    url(r'^tag_implications/(?P<implication_id>[0-9]+)/disapprove/$', views.implication_disapprove, name='implication_disapprove'),
+    re_path(r'^tag_aliases/(?P<alias_id>[0-9]+)/approve/$', views.alias_approve, name='alias_approve'),
+    re_path(r'^tag_implications/(?P<implication_id>[0-9]+)/approve/$', views.implication_approve, name='implication_approve'),
+    re_path(r'^tag_aliases/(?P<alias_id>[0-9]+)/disapprove/$', views.alias_disapprove, name='alias_disapprove'),
+    re_path(r'^tag_implications/(?P<implication_id>[0-9]+)/disapprove/$', views.implication_disapprove, name='implication_disapprove'),
+    re_path(r'^profile/(?P<account_slug>[\w-]+)/$', account_views.profile, name='profile'),
 ]

--- a/boorunaut/urls.py
+++ b/boorunaut/urls.py
@@ -14,15 +14,15 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.conf import settings
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.conf.urls.static import static
 from django.contrib import admin
-from django.urls import path
+from django.urls import re_path
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    url(r'^', include('booru.urls')),
-    url(r'^account/', include('account.urls')),
+    re_path(r'^', include('booru.urls')),
+    re_path(r'^account/', include('account.urls')),
 ]
 
 if settings.DEBUG == True:


### PR DESCRIPTION
The module 'django.conf.url' was moved to 'django.urls' and the function 'url' was moved to 're_path', because the first one is soon to be deprecated.