### PR TITLE
Replacing Markdown Deux with Markdownify

### DIFF
--- a/booru/setup/project_template/project_name/settings.py
+++ b/booru/setup/project_template/project_name/settings.py
@@ -50,7 +50,7 @@ INSTALLED_APPS = [
     'booru.core',
     # Dependency apps
     'taggit',
-    'markdown_deux',
+    'markdownify.apps.MarkdownifyConfig',
     'simple_history',
     'rolepermissions',
     'crispy_forms',

--- a/booru/templates/booru/account/profile.html
+++ b/booru/templates/booru/account/profile.html
@@ -128,11 +128,11 @@
                 {% endif %}
             </h3>
 
-            {% load markdown_deux_tags %}
+            {% load markdownify %}
 
             <div id="about-data">
                 {% if account.about %}
-                {{ account.about|markdown }}
+                {{ account.about|markdownify }}
                 {% else %}
                 <p class="text-muted">This user have not written nothing about themselves yet!</p>
                 {% endif %}
@@ -173,8 +173,8 @@
                             </div>
                         </div>
                         <div class="comment col-9">
-                            {% load markdown_deux_tags %}
-                            {{comment.content|markdown}}
+                            {% load markdownify %}
+                            {{comment.content|markdownify}}
                         </div>
                     </div>
                 </div>

--- a/booru/templates/booru/account/register.html
+++ b/booru/templates/booru/account/register.html
@@ -13,7 +13,7 @@
         <div class="col">
             <h1>Register</h1>
             <p class="text-muted">
-                With a account, you are able to comment, upload images and mark favorites. These actions are public and are subject to web-crawlers. <br/>
+                With an account, you are able to comment, upload images and mark favorites. These actions are public and are subject to web-crawlers. <br/>
                 Choose a username you are comfortable being associated with.
             </p>
 

--- a/booru/templates/booru/base.html
+++ b/booru/templates/booru/base.html
@@ -55,9 +55,9 @@
 
         {% if SITE_ANNOUNCEMENT %}
         <div class="container">
-            {% load markdown_deux_tags %}
+            {% load markdownify %}
             <div class="alert alert-info" role="alert">
-                {{SITE_ANNOUNCEMENT|markdown}}
+                {{SITE_ANNOUNCEMENT|markdownify}}
             </div>
         </div>
         {% endif %}

--- a/booru/templates/booru/core/privacy_policy.html
+++ b/booru/templates/booru/core/privacy_policy.html
@@ -10,13 +10,13 @@
 {% endblock %}
 
 {% block body %}
-{% load markdown_deux_tags %}
+{% load markdownify %}
 <div class="container">
     <div class="row">
         <div class="col">
             <h1>Privacy policy</h1>
             <div>
-                {{ privacy_policy|markdown }}
+                {{ privacy_policy|markdownify }}
             </div>
         </div>
     </div>

--- a/booru/templates/booru/core/terms_of_service.html
+++ b/booru/templates/booru/core/terms_of_service.html
@@ -10,13 +10,13 @@
 {% endblock %}
 
 {% block body %}
-{% load markdown_deux_tags %}
+{% load markdownify %}
 <div class="container">
     <div class="row">
         <div class="col">
             <h1>Terms of Service</h1>
             <div>
-                {{ terms_of_service|markdown }}
+                {{ terms_of_service|markdownify }}
             </div>
         </div>
     </div>

--- a/booru/templates/booru/post_detail.html
+++ b/booru/templates/booru/post_detail.html
@@ -34,7 +34,7 @@
 {% block body %}
     {% load humanize %}
     {% load number_converter %}
-    {% load markdown_deux_tags %}
+    {% load markdownify %}
     {% load permission_tags %}
     {% load crispy_forms_tags %}
     <div class="row">
@@ -329,7 +329,7 @@
                 <div class="card col-10">
                     <div class="card-body">
                         <h5 class="card-title">Description</h5>
-                        <p class="card-text">{{post.description|markdown}}</p>
+                        <p class="card-text">{{post.description|markdownify}}</p>
                     </div>
                 </div>
             </div>
@@ -379,7 +379,7 @@
                                 {% endif %}
                             </div>
                             <div class="comment col-9">
-                                {{comment.content|markdown}}
+                                {{comment.content|markdownify}}
                             </div>
                         </div>
                         {% if user|can:'manage_comments' %}

--- a/booru/templates/booru/staff_mod_queue.html
+++ b/booru/templates/booru/staff_mod_queue.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block content %}
-{% load markdown_deux_tags %}
+{% load markdownify %}
 {% load crispy_forms_tags %}
 <div class="col-12 text-white bg-primary">
     <h1 class="h4 text-uppercase p-3 mb-0"><i class="fas fa-tasks mr-3"></i>Moderation Queue</h1>
@@ -52,7 +52,7 @@
                         <a href="{{ flag.post.get_absolute_url }}">{{ flag.post }}</a>
                     </td>
                     <td>
-                        {{ flag.reason |markdown }}
+                        {{ flag.reason |markdownify }}
                     </td>
                     <td><a href="{{ flag.creator.get_absolute_url }}">{{ flag.creator }}</a></td>
                     <td>{{ flag.timestamp }}</td>

--- a/booru/templates/booru/tag_confirm_delete.html
+++ b/booru/templates/booru/tag_confirm_delete.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block body %}
-    {% load markdown_deux_tags %}
+    {% load markdownify %}
     <div class="container">
         <form method="post">{% csrf_token %}
             <h1>Delete tag</h1>

--- a/booru/templates/booru/tag_detail.html
+++ b/booru/templates/booru/tag_detail.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block body %}
-    {% load markdown_deux_tags %}
+    {% load markdownify %}
     {% load permission_tags %}
     <div class="container">
         <div class="row">
@@ -36,7 +36,7 @@
                         {% if tag.description %}
                         <tr>
                             <td><strong>Description:</strong></td>
-                            <td>{{tag.description|markdown}}</td>
+                            <td>{{tag.description|markdownify}}</td>
                         </tr>
                         {% endif %}
                         <tr>

--- a/booru/templates/booru/tag_revision_diff.html
+++ b/booru/templates/booru/tag_revision_diff.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block body %}
-    {% load markdown_deux_tags %}
+    {% load markdownify %}
     <div class="container">
         <div class="row mb-1">
             <h1>Tag: <a href="{% url 'booru:tag_history' tag.id %}">{{tag}}</a></h1>

--- a/devproject/settings.py
+++ b/devproject/settings.py
@@ -51,7 +51,7 @@ INSTALLED_APPS = [
     'booru.core',
     # Dependency apps
     'taggit',
-    'markdown_deux',
+    'markdownify.apps.MarkdownifyConfig',
     'simple_history',
     'rolepermissions',
     'crispy_forms',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 diff-match-patch==20200713
 Django==4.1.5
 django-crispy-forms==1.14.0
-django-markdown-deux==1.0.5
+django-markdownify==0.9.2
 django-role-permissions==3.1.1
 django-simple-history==3.2.0
 django-taggit==3.1.0


### PR DESCRIPTION
Markdown Deux is not compatible with the latest version of Django and it's not maintained anymore, so I replaced it with Markdownify. Also fixed a minor spelling mistake.