### PR TITLE
Replace usage of Image.ANTIALIAS with Image.LANCZOS

### DIFF
--- a/booru/utils.py
+++ b/booru/utils.py
@@ -33,7 +33,7 @@ def space_joiner(tags):
 def image_resizer(original_image, size):
     img_io = io.BytesIO()
     resized_image = original_image.copy()
-    resized_image.thumbnail(size, ImagePIL.ANTIALIAS)
+    resized_image.thumbnail(size, ImagePIL.LANCZOS)
     resized_image.convert('RGB').save(img_io, format='JPEG', quality=100)
     img_content = ContentFile(img_io.getvalue(), original_image.filename)
     return img_content


### PR DESCRIPTION
`Image.ANTIALIAS` has been removed in pillow version 10.0.0 and beyond. The [release notes](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#constants) state to use `Image.LANCZOS` or `Image.Resampling.LANCZOS` instead. Tested on a development instance and my failing uploads now work fine

Fixes #181 